### PR TITLE
Update encryptfs.md

### DIFF
--- a/encryptfs.md
+++ b/encryptfs.md
@@ -51,7 +51,7 @@ The node is able to boot unattended. However, a manually-entered passphrase must
 
 1. Create a new data folder.
     ```
-    sudo mkdir ~/.rocketpool/data 
+    mkdir ~/.rocketpool/data 
     ```
 
 1. Encrypt the data folder by running RPunlock. 


### PR DESCRIPTION
`~/.rocketpool/data` should be user-owned, or smartnode breaks when trying to add missing paths